### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "set-headers": "1.0.0",
     "slasher": "1.0.0",
     "slashify": "0.1.0",
-    "stacked": "1.1.0",
+    "stacked": "1.1.1",
     "static-router": "1.0.4",
     "update-notifier": "0.2.2",
     "van": "0.0.4"


### PR DESCRIPTION
Version 1.1.0 of `stacked` used the now deprecated `res.headerSent`. Yesterday I submitted a pull request to the maintainer to update to `res.headersSent` which has been merged in. Updating to version 1.1.1 will remove all of the deprecation warnings one would normally see while running `superstatic`. Cheers.