### PR TITLE
Set "main" to correct path and fix index file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,2 @@
-
-var exports = module.exports = require('./superstatic');
+exports = module.exports = require('./superstatic');
 exports.server = require('./server');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "superstatic",
   "version": "2.1.0",
   "description": "Superstatic: a static file server for fancy apps",
-  "main": "lib/superstatic.js",
+  "main": "./lib",
   "scripts": {
     "test": "npm run lint && npm run test-unit && npm run test-integration",
     "test-unit": "mocha test/unit/**",


### PR DESCRIPTION
Right now the path for "main" isn't consistent with the documented exports of the library. Also, there's no need to do `var exports` because `exports` is already defined in the context of a module.