### PR TITLE
make sure path and extensions match

### DIFF
--- a/lib/middleware/static-router.js
+++ b/lib/middleware/static-router.js
@@ -2,6 +2,7 @@ var slasher = require('glob-slasher');
 var globject = require('globject');
 var url = require('fast-url-parser');
 var flattenToObject = require('flatten-to-object');
+var path = require('path');
 
 module.exports = function (imports) {
   
@@ -14,6 +15,11 @@ module.exports = function (imports) {
     var filepath = routes(slasher(pathname));
     
     if (!filepath) {
+      return next();
+    }
+    
+    var ext = path.extname(pathname);
+    if (ext && ext !== path.extname(filepath)) {
       return next();
     }
     

--- a/test/unit/middleware/static-router.js
+++ b/test/unit/middleware/static-router.js
@@ -96,6 +96,20 @@ describe('static router', function () {
       .expect(404)
       .end(done);
   });
+
+  it('ensures matching file extension', function (done) {
+    
+    app.use(staticRouter({
+      routes: {
+        '**': "/index.html"
+      }
+    }));
+    
+    request(app)
+      .get('/index.js')
+      .expect(404)
+      .end(done);
+  });
   
   describe('uses first match', function () {
     


### PR DESCRIPTION
This was bothering me :grimacing: -- for example, if I want `js` don't send `html`. 

Content type warnings can be hard to keep track of in the console when working with media iframes, and with fonts or async metrics scripts, you might not find out until you push. 
