### PR TITLE
Replace tiny-lr with mini-lr for npm v3 support

### DIFF
--- a/lib/utils/reloader.js
+++ b/lib/utils/reloader.js
@@ -1,4 +1,4 @@
-var tinylr = require('tiny-lr');
+var minilr = require('mini-lr');
 var liveReload = require('connect-livereload');
 var format = require('chalk');
 var chokidar = require('chokidar');
@@ -15,7 +15,7 @@ module.exports = function reloader (options) {
   var port = options.port || 35729;
   
   // Start live reload server
-  tinylr().listen(port, function() {
+  minilr().listen(port, function() {
     
     console.log('\n== Livereload listening on port %s. ==', port);
     
@@ -24,7 +24,7 @@ module.exports = function reloader (options) {
     watcher.on('change', function (filepath) {
         
       console.log('[Livereload] %s changed. Updating page.', filepath); 
-      tinylr.changed(filepath);
+      minilr.changed(filepath);
     });
   });
   

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "join-path": "^1.0.0",
     "lodash": "^3.1.0",
     "mime-types": "^2.0.4",
+    "mini-lr": "^0.1.8",
     "minimatch": "^2.0.1",
     "morgan": "^1.5.0",
     "nash": "^2.0.0",
@@ -88,7 +89,6 @@
     "set-headers": "^1.0.0",
     "string-length": "^1.0.0",
     "through2": "^2.0.0",
-    "tiny-lr": "^0.1.5",
     "try-require": "^1.0.0",
     "update-notifier": "0.3.2"
   },


### PR DESCRIPTION
Tiny-lr has an issue with npm v3's flat module directory, reference [here](https://github.com/mklabs/tiny-lr/issues/91).

However, the project hasn't been updated in quite some time, and the maintainers have a history of abandoning it.  In order to unblock npm v3 users, I've forked the project and released it under the name `mini-lr`. You can find the new repository [here](http://jhawk.co/mini-lr). I recommend updating your project to use the latest release in order to enable npm v3 usage. Thanks!