### PR TITLE
Detect "fake" stats-like objects that aren't instances of fs.Stats

### DIFF
--- a/lib/dfs.js
+++ b/lib/dfs.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var _ = require('lodash');
 
 var fs = require('fs-extra');
 var send = require('send');
@@ -95,13 +96,27 @@ module.exports = function (config) {
 
     encoding = encoding || 'utf8';
 
-    if (!(data instanceof fs.Stats)) {
+    if (!isStats(data)) {
       data = !Buffer.isBuffer(data)
         ? new Buffer(data, encoding)
         : data;
     }
 
     return etag(data, {weak: false});
+  }
+
+  function isStats(obj) {
+
+    if (typeof fs.Stats === 'function' && obj instanceof fs.Stats) {
+      return true;
+    }
+
+    var toString = Object.prototype.toString;
+    return obj && typeof obj === 'object'
+      && 'ctime' in obj && toString.call(obj.ctime) === '[object Date]'
+      && 'mtime' in obj && toString.call(obj.mtime) === '[object Date]'
+      && 'ino' in obj && typeof obj.ino === 'number'
+      && 'size' in obj && typeof obj.size === 'number';
   }
 
   // TODO: expose this as a "resolve" function. This not

--- a/test/unit/dfs.js
+++ b/test/unit/dfs.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var fs = require('fs-extra');
 var join = require('join-path');
 var expect = require('chai').expect;
@@ -150,5 +151,14 @@ describe('default provider', function () {
 
     expect(providerTag).to.equal(statTag);
     done();
+  });
+
+  it('generateEtag() with stats-like object', function () {
+
+    var stat = _.cloneDeep(fs.statSync('.tmp/index.html'));
+    var providerTag = provider.generateEtag(stat);
+    var statTag = etag(stat, {weak: false});
+
+    expect(providerTag).to.equal(statTag);
   });
 });


### PR DESCRIPTION
This uses the etag package's implementation of isStats. The problem is caused by older versions of the ubiquitous graceful-fs package, which causes the return value of fs.stat to fail an instanceof check for fs.Stats. See #177 for more information.